### PR TITLE
Add favorite list write support (modifyfavourite + PUT favoriteLists)

### DIFF
--- a/src/philipstv/api.py
+++ b/src/philipstv/api.py
@@ -20,7 +20,9 @@ from .model import (
     ApplicationShort,
     CurrentChannel,
     CurrentVolume,
+    FavouriteList,
     InputKey,
+    ModifyFavourite,
     PairingGrantPayload,
     PairingRequestPayload,
     PairingRequestResponse,
@@ -153,6 +155,41 @@ class PhilipsTVAPI:
         """Send request to set the channel."""
         self._api_post("activities/tv", channel)
 
+    def modify_favourite(self, list_id: int, payload: ModifyFavourite) -> None:
+        """Send request to add or remove channels from a favourite list.
+
+        This uses the ``POST /6/channeldb/tv/modifyfavourite/{list_id}`` endpoint
+        discovered via firmware decompilation.
+
+        Note:
+            The TV must be actively watching a channel (not on the home screen),
+            otherwise the API returns 503.
+
+        Args:
+            list_id: Favourite list ID (1-8).
+            payload: Channels to add/remove and optional list rename.
+
+        """
+        self._api_post(f"channeldb/tv/modifyfavourite/{list_id}", payload)
+
+    def set_favourite_list(self, list_id: int, favourite_list: FavouriteList) -> None:
+        """Send request to replace an entire favourite list.
+
+        This uses the ``PUT /6/channeldb/tv/favoriteLists/{list_id}`` endpoint
+        discovered via firmware decompilation. The endpoint requires PUT;
+        POST returns 405.
+
+        Note:
+            The TV must be actively watching a channel (not on the home screen),
+            otherwise the API returns 503.
+
+        Args:
+            list_id: Favourite list ID (1-8).
+            favourite_list: The complete ordered list of channel ccids.
+
+        """
+        self._api_put(f"channeldb/tv/favoriteLists/{list_id}", favourite_list)
+
     def input_key(self, key: InputKey) -> None:
         """Send request to simulate pressing key on the remote."""
         self._api_post("input/key", key)
@@ -259,6 +296,10 @@ class PhilipsTVAPI:
     def _api_post(self, path: str, payload: APIObject | None = None) -> Any:
         with _wrap_unauthorized_exceptions("POST", path):
             return self._tv.post(self._api_path(path), payload.dump() if payload else None)
+
+    def _api_put(self, path: str, payload: APIObject | None = None) -> Any:
+        with _wrap_unauthorized_exceptions("PUT", path):
+            return self._tv.put(self._api_path(path), payload.dump() if payload else None)
 
     def _api_get(self, path: str) -> Any:
         with _wrap_unauthorized_exceptions("GET", path):

--- a/src/philipstv/model/__init__.py
+++ b/src/philipstv/model/__init__.py
@@ -26,6 +26,9 @@ from .channels import (
     ChannelListID,
     ChannelShort,
     CurrentChannel,
+    FavouriteIDList,
+    FavouriteList,
+    ModifyFavourite,
     SetChannel,
 )
 from .general import PowerState, PowerStateValue
@@ -64,8 +67,11 @@ __all__ = [
     "CurrentChannel",
     "CurrentVolume",
     "DeviceInfo",
+    "FavouriteIDList",
+    "FavouriteList",
     "InputKey",
     "InputKeyValue",
+    "ModifyFavourite",
     "PairingAuthInfo",
     "PairingGrantPayload",
     "PairingRequestPayload",

--- a/src/philipstv/model/channels.py
+++ b/src/philipstv/model/channels.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from pydantic import Field
 
 from .base import APIObject
@@ -27,6 +29,10 @@ class ModifyFavourite(APIObject):
     """Channels to remove from the favourite list."""
     name: str | None = None
     """Optional new name for the favourite list."""
+
+    def dump(self) -> Any:
+        """Dump excluding None fields — the TV firmware rejects null values."""
+        return self.model_dump(by_alias=True, exclude_none=True)
 
 
 class FavouriteList(APIObject):

--- a/src/philipstv/model/channels.py
+++ b/src/philipstv/model/channels.py
@@ -3,6 +3,47 @@ from pydantic import Field
 from .base import APIObject
 
 
+class FavouriteIDList(APIObject):
+    """Model of an ID list used inside a modify favourite request."""
+
+    id: list[int]
+    """List of channel ccid values."""
+
+
+class ModifyFavourite(APIObject):
+    """Model of a modify favourite request (add/remove channels).
+
+    Corresponds to ``POST /6/channeldb/tv/modifyfavourite/{list_id}``.
+
+    Note:
+        The TV must be actively watching a channel (not on the home screen),
+        otherwise the API returns 503.
+
+    """
+
+    add: FavouriteIDList | None = None
+    """Channels to add to the favourite list."""
+    remove: FavouriteIDList | None = None
+    """Channels to remove from the favourite list."""
+    name: str | None = None
+    """Optional new name for the favourite list."""
+
+
+class FavouriteList(APIObject):
+    """Model of a favourite list replacement request.
+
+    Corresponds to ``PUT /6/channeldb/tv/favoriteLists/{list_id}``.
+
+    Note:
+        The TV must be actively watching a channel (not on the home screen),
+        otherwise the API returns 503.
+
+    """
+
+    channels: list[int]
+    """Ordered list of channel ccid values that will replace the entire favourite list."""
+
+
 class ChannelID(APIObject):
     """Model of a channel change request."""
 

--- a/src/philipstv/tv.py
+++ b/src/philipstv/tv.py
@@ -87,6 +87,26 @@ class PhilipsTV:
         _LOGGER.debug("Response: %s %s", response.status_code, response_body)
         return response_body
 
+    def put(self, path: str, payload: Any = None) -> Any:
+        """Send `PUT` request.
+
+        Args:
+            path: The path to send the request to.
+            payload: Request payload to send.
+
+        Returns:
+            The TV's JSON response body or ``None``.
+
+        """
+        _LOGGER.debug("Request: PUT %s %s", path, payload)
+        url = urljoin(self.url, path)
+        with _wrap_http_exceptions("PUT", url):
+            response = self._session.put(url, json=payload)
+            response.raise_for_status()
+        response_body = response.json() if response.content else None
+        _LOGGER.debug("Response: %s %s", response.status_code, response_body)
+        return response_body
+
     def get(self, path: str) -> Any:
         """Send `GET` request.
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -10,14 +10,17 @@ class FakePhilipsTV(PhilipsTV):
         self,
         post_responses: dict[str, Any] | None = None,
         get_responses: dict[str, Any] | None = None,
+        put_responses: dict[str, Any] | None = None,
     ) -> None:
         self.host = ""
         self._auth: Credentials | None = None
         self.post_requests: dict[str, Any] = {}
         self.get_requests: set[str] = set()
+        self.put_requests: dict[str, Any] = {}
 
         self.post_responses = post_responses or {}
         self.get_responses = get_responses or {}
+        self.put_responses = put_responses or {}
 
     @property
     def auth(self) -> Credentials | None:
@@ -33,6 +36,13 @@ class FakePhilipsTV(PhilipsTV):
             return self._raise_or_return(self.post_responses[path])
         except KeyError as err:
             raise PhilipsTVError("POST", path, 404) from err
+
+    def put(self, path: str, payload: Any = None) -> Any:
+        self.put_requests[path] = payload
+        try:
+            return self._raise_or_return(self.put_responses[path])
+        except KeyError as err:
+            raise PhilipsTVError("PUT", path, 404) from err
 
     def get(self, path: str) -> Any:
         self.get_requests.add(path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -288,8 +288,6 @@ def test_modify_favourite_add_only() -> None:
     assert fake_tv.post_requests == {
         "6/channeldb/tv/modifyfavourite/3": {
             "add": {"id": [10]},
-            "remove": None,
-            "name": None,
         }
     }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -29,8 +29,11 @@ from philipstv.model import (
     CurrentChannel,
     CurrentVolume,
     DeviceInfo,
+    FavouriteIDList,
+    FavouriteList,
     InputKey,
     InputKeyValue,
+    ModifyFavourite,
     PairingAuthInfo,
     PairingGrantPayload,
     PairingRequestPayload,
@@ -247,6 +250,63 @@ def test_get_all_channels() -> None:
             )
         ],
     )
+
+
+def test_modify_favourite() -> None:
+    fake_tv = FakePhilipsTV(
+        post_responses={"6/channeldb/tv/modifyfavourite/1": None}
+    )
+
+    PhilipsTVAPI(fake_tv).modify_favourite(
+        1,
+        ModifyFavourite(
+            add=FavouriteIDList(id=[22, 23]),
+            remove=FavouriteIDList(id=[45]),
+            name="Favourites 1",
+        ),
+    )
+
+    assert fake_tv.post_requests == {
+        "6/channeldb/tv/modifyfavourite/1": {
+            "add": {"id": [22, 23]},
+            "remove": {"id": [45]},
+            "name": "Favourites 1",
+        }
+    }
+
+
+def test_modify_favourite_add_only() -> None:
+    fake_tv = FakePhilipsTV(
+        post_responses={"6/channeldb/tv/modifyfavourite/3": None}
+    )
+
+    PhilipsTVAPI(fake_tv).modify_favourite(
+        3,
+        ModifyFavourite(add=FavouriteIDList(id=[10])),
+    )
+
+    assert fake_tv.post_requests == {
+        "6/channeldb/tv/modifyfavourite/3": {
+            "add": {"id": [10]},
+            "remove": None,
+            "name": None,
+        }
+    }
+
+
+def test_set_favourite_list() -> None:
+    fake_tv = FakePhilipsTV(
+        put_responses={"6/channeldb/tv/favoriteLists/2": None}
+    )
+
+    PhilipsTVAPI(fake_tv).set_favourite_list(
+        2,
+        FavouriteList(channels=[22, 23, 24]),
+    )
+
+    assert fake_tv.put_requests == {
+        "6/channeldb/tv/favoriteLists/2": {"channels": [22, 23, 24]}
+    }
 
 
 def test_input_key() -> None:


### PR DESCRIPTION
Philips never documented these, but the TV firmware has write endpoints for
favorites. Found by decompiling xtv.apk (the JointSpace HTTP server) from
a 2019 Android TV via ADB + jadx.

What's new:
- `modify_favourite(list_id, payload)` — POST to add/remove channels
- `set_favourite_list(list_id, favourite_list)` — PUT to replace the whole list
- Three new Pydantic models: `ModifyFavourite`, `FavouriteList`, `FavouriteIDList`
- `PhilipsTV.put()` method (was missing entirely)
- 3 tests, all passing (68 total)

The weird bits about this API:
- The add/remove endpoint lives at `/modifyfavourite/{id}`, not `/favoriteLists/{id}`
- PUT works on `/favoriteLists/{id}`, but POST returns 405
- The JSON body nests the ccid arrays: `{"add": {"id": [22, 23]}}` not `{"add": [22, 23]}`
- Returns 503 if the TV is on the home screen instead of watching a channel

Tested on Philips 2019 Android TV (MSAF_2019_P, API v6.4.0).
Full endpoint docs: eslavnov/pylips#126